### PR TITLE
Installing jupyter

### DIFF
--- a/overviews/5 Data/install_jupyter.sh
+++ b/overviews/5 Data/install_jupyter.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Installs jupyter and sets configuration for compatibility with CS50 IDE
+
+# Installing jupyter and initialzing the config
+yes | pip install --user jupyter
+jupyter notebook -y --generate-config
+
+# Os is required to get the C9_PID later
+echo "import os" >> /home/ubuntu/.jupyter/jupyter_notebook_config.py
+
+# Settings for the CS50 IDE
+echo "c.NotebookApp.ip = '0.0.0.0'" >> /home/ubuntu/.jupyter/jupyter_notebook_config.py
+echo "c.NotebookApp.port = 8080" >> /home/ubuntu/.jupyter/jupyter_notebook_config.py
+echo "c.NotebookApp.open_browser = False" >> /home/ubuntu/.jupyter/jupyter_notebook_config.py
+
+# Setting the displayed URL to the correct amazonaws URL
+echo "c.NotebookApp.custom_display_url = 'https://' + os.environ['C9_PID'] + '.vfs.cloud9.us-west-2.amazonaws.com'" >> /home/ubuntu/.jupyter/jupyter_notebook_config.py

--- a/overviews/5 Data/overview.md
+++ b/overviews/5 Data/overview.md
@@ -26,6 +26,12 @@ Log into <https://cs50.io/> and execute the below in a terminal window.
     mkdir ~/workspace/pset5/
     cd ~/workspace/pset5/
 
+In this weeks problems, we will be using jupyter notebook. In order to install jupyter, execute the below in a terminal window.
+
+    wget https://raw.githubusercontent.com/uva/programmeren-ik/master/overviews/5%20Data/install_jupyter.sh
+    bash install_jupyter.sh
+    rm install_jupyter.sh
+
 
 ## What to Do
 

--- a/problems/climate/climate.md
+++ b/problems/climate/climate.md
@@ -2,13 +2,13 @@
 
 ## Jupyter Notebook
 
-Om je voor te bereiden op Netwerk Analyse en verschillende andere vervolgvakken, maak je nu alvast kennis met Jupyter Notebook. Dat is een omgeving waarin je kan programmeren als wel tekst kan schrijven. Een ideale omgeving om de resultaten van jouw programma te presenteren, maar ook een ideaal formaat voor vakken (zoals dit vak) om hun opdrachten in te verspreiden.
+Om je voor te bereiden op Netwerk Analyse en verschillende andere vervolgvakken, maak je nu alvast kennis met Jupyter Notebook. Dat is een omgeving waarin je kan programmeren als wel tekst kan schrijven. Een ideale omgeving om de resultaten van jouw programma te presenteren, maar ook een ideaal formaat voor vakken (zoals dit vak) om hun opdrachten in te verspreiden. Jupyter moet eerst geïnstalleerd worden. Hoe je dit doet lees je in de introductie van deze module.
 
 Je runt jupyter notebook in de cs50 IDE d.m.v.
 
-    jupyter notebook --ip=0.0.0.0 --port=8080 --no-browser
+    jupyter notebook
 
-Je ziet nu een nieuwe webpagina openen. Er zijn hier drie tabjes: Files, Running, en Clusters. We hebben nu enkel de eerste nodig. Navigeer binnen Files naar een plek waar je jouw werk wilt opslaan. Dit zijn simpelweg de mappen op jouw computer, dus je kan altijd een nieuwe map aanmaken voor jouw werk. Zodra je bent aangekomen, klik je rechtsboven op het dropdown-menu `new`. Kies hier voor een Python3 notebook. Dan opent er een nieuw tabblad met daarin een nieuwe notebook.
+Klik vervolgens op de link met `vfs.cloud9.us-west-2.amazonaws.com` erin. Er zijn hier drie tabjes: Files, Running, en Clusters. We hebben nu enkel de eerste nodig. Navigeer binnen Files naar een plek waar je jouw werk wilt opslaan. Dit zijn simpelweg de mappen op jouw computer, dus je kan altijd een nieuwe map aanmaken voor jouw werk. Zodra je bent aangekomen, klik je rechtsboven op het dropdown-menu `new`. Kies hier voor een Python3 notebook. Dan opent er een nieuw tabblad met daarin een nieuwe notebook.
 
 Voor we beginnen, ga linksboven naar het dropdown-menu file en klik rename. Noem je nieuwe notebook: auto. In jouw notebook heb je zogenaamde cells. Dat zijn vakken waar je zowel code als tekst kan schrijven. Aangezien we een Python 3 notebook hebben, kunnen we Python3 code schrijven. Probeer maar eens: `print(3 * 4)`. Voer je dit in de cell, en druk je vervolgens op shift+enter (zo run je een cell), dan zie je direct onder de cell de uitkomst! Druk je enkel op enter, dan krijg je een extra regel binnen de cell.
 


### PR DESCRIPTION
Unfortunately, Jupyter does not appear to be installed in the CS50 IDE by default anymore. 

After installing Jupyter normally and launching a notebook, the terminal will provide a link which is also the link used when the user clicks on 'Web Server' within the IDE. When you open a notebook through this link, the websocket connection will fail and the kernel will appear to be loading indefinitely. No code will actually run, either.

The URL that should be used is very annoying to find (https:// + the environment variable for C9_PID + .vfs.cloud9.us-west-2.amazonaws.com). This PR contains an installation script (with instructions) which installs jupyter and puts the correct base URL in the Jupyter config. This way, the correct URL will show up in the terminal when a jupyter notebook is launched.

Additionally, since the script modifies the config anyway, I added the ip, port and no-browser setting too. This way, a notebook can simply be launched with `jupyter notebook`.